### PR TITLE
Added rate boost to synth settings rring for consistency with NVDA 2019.2 and later

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -89,7 +89,7 @@ langsAnnotations={
 
 class SynthDriver(synthDriverHandler.SynthDriver):
 	supportedSettings=(SynthDriver.VoiceSetting(), SynthDriver.VariantSetting(),
-	SynthDriver.RateSetting(), BooleanSynthSetting("rateBoost", _("Rate boos&t")),
+	SynthDriver.RateSetting(), BooleanSynthSetting("rateBoost", _("Rate boos&t"), True),
 	SynthDriver.PitchSetting(), SynthDriver.InflectionSetting(), SynthDriver.VolumeSetting(), NumericSynthSetting("hsz", _("Head Size"), False), NumericSynthSetting("rgh", _("Roughness"), False), NumericSynthSetting("bth", _("Breathiness"), False), BooleanSynthSetting("backquoteVoiceTags", _("Enable backquote voice &tags"), False))
 	description='IBMTTS'
 	name='ibmeci'


### PR DESCRIPTION
Starting with NVDA 2019.2, rate boost is now configurable from the synth settings ring. Since the IBMTTS driver supports this, added it to the synth settings ring for consistency.